### PR TITLE
0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Plugin page: http://plugins.jetbrains.com/plugin/7558
 1. Install next plugins for Intellij
   * https://plugins.jetbrains.com/plugin/6606-grammar-kit
 
-2. Go to `Zephir.bnf` file and run "Generate parser code" through context menu
-3. Go to `src/com/zephir/Zephir.flex` and run "Run JFlex generator" through context menu
-4. Run the plugin by Menu -> Run -> Run
+2. Go to `Zephir.bnf` file and run "Generate parser code" through context menu 
+3. Go to `src/com/zephir/lexer/Zephir.flex` and run "Run JFlex generator" through context menu
+   And specify idea-plugin/lib/ directory to get "lib/jflex-*.jar" file
+4. Specify */gen* folder as *source code folder* Menu -> File -> Project Structure...
+   In *Modules* tab specify */gen* folder as "Source"
+5. Run the plugin by Menu -> Run -> Run
 
 ## Links
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/phalcon/zephir-idea-plugin">
   <id>com.zephir</id>
   <name>Zephir</name>
-  <version>0.3.2-beta3</version>
+  <version>0.3.2</version>
   <vendor email="support@phalconphp.com" url="https://zephir-lang.com">Zephir Team</vendor>
 
   <description><![CDATA[
@@ -12,18 +12,11 @@
     ]]></description>
 
   <change-notes><![CDATA[
+        <li><b>0.3.2</b> Improved syntax support</li>
         <li><b>0.3.2-beta3</b> Fixed regex recognition bug. Added syntax support for constructions like {var} </li>
         <li><b>0.3.2-beta2</b>: Improved syntax support. Fixed completion bug when invoking AC in method definition block</li>
         <li><b>0.3.2-beta1</b>: Introduced class members in completion list</li>
         <li><b>0.3.1</b>: Fixed much bugs with syntax recognition, fixed extra space in completion for method params</li>
-        <li><b>0.3.0</b>: Fixed many bugs with syntax recognition, added few words to highlight, improved completion</li>
-        <li><b>0.2.5</b>: Fixed "switch" keyword detection</li>
-        <li><b>0.2.4</b>: Added brace matching</li>
-        <li><b>0.2.3</b>: Fixed build</li>
-        <li><b>0.2.2</b>: Improve highlighter, added color settings page</li>
-        <li><b>0.2.1</b>: Disabled "New Zephir class" dialog</li>
-        <li><b>0.2.0</b>: Added lexer and simple syntax highlighter</li>
-        <li><b>0.1.0</b>: Initial plugin</li>
     ]]></change-notes>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,11 +12,16 @@
     ]]></description>
 
   <change-notes><![CDATA[
-        <li><b>0.3.2</b> Improved syntax support</li>
-        <li><b>0.3.2-beta3</b> Fixed regex recognition bug. Added syntax support for constructions like {var} </li>
-        <li><b>0.3.2-beta2</b>: Improved syntax support. Fixed completion bug when invoking AC in method definition block</li>
-        <li><b>0.3.2-beta1</b>: Introduced class members in completion list</li>
+        <li><b>0.3.2</b>: Completion list now shows members of class. Improved syntax support</li>
         <li><b>0.3.1</b>: Fixed much bugs with syntax recognition, fixed extra space in completion for method params</li>
+        <li><b>0.3.0</b>: Fixed many bugs with syntax recognition, added few words to highlight, improved completion</li>
+        <li><b>0.2.5</b>: Fixed "switch" keyword detection</li>
+        <li><b>0.2.4</b>: Added brace matching</li>
+        <li><b>0.2.3</b>: Fixed build</li>
+        <li><b>0.2.2</b>: Improve highlighter, added color settings page</li>
+        <li><b>0.2.1</b>: Disabled "New Zephir class" dialog</li>
+        <li><b>0.2.0</b>: Added lexer and simple syntax highlighter</li>
+        <li><b>0.1.0</b>: Initial plugin</li>
     ]]></change-notes>
 
   <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->

--- a/src/com/zephir/Zephir.bnf
+++ b/src/com/zephir/Zephir.bnf
@@ -194,7 +194,7 @@ method_definition ::= method_header '(' arguments* ')' return_type? method_body 
 method_modifiers ::= 'static' | 'inline' | 'deprecated' | 'final'
 method_body ::= code_block
 
-private method_header ::= (visibility method_modifiers* | method_modifiers* visibility  ) FUNCTION id
+private method_header ::= (visibility | method_modifiers)* FUNCTION id
 code_block ::= '{' code* '}' {pin=1}
 
 return_type ::= '->' (type | 'null') ('|' (type | 'null'))* {pin(".*")=1}

--- a/src/com/zephir/Zephir.bnf
+++ b/src/com/zephir/Zephir.bnf
@@ -224,6 +224,7 @@ private void_type ::= 'void'
 code ::= declaration_statement |
          let_statement |
          call_statement |
+         chain_of_call_statement |
          control_statement |
          loop_statement |
          switch_statement |
@@ -295,8 +296,11 @@ expr ::= unary_expr |
          special_group_expr
 
 private bool_group_expr ::= bool_expr | ternary_expr | empty_expr | isset_expr | fetch_expr | instanceof_expr
-private primary_group_expr ::= static_call_expr | literal_expr | paren_expr | precast_expr | callback_expr | call_expr | clone_expr
+private primary_group_expr ::= chain_of_call_expr | static_call_expr | literal_expr | paren_expr | precast_expr | callback_expr | call_expr | clone_expr
 private special_group_expr ::= new_expr | typeof_expr
+
+chain_of_call_statement ::= chain_of_call_expr ;
+chain_of_call_expr ::= (paren_expr '->') expr
 
 bit_expr ::= expr bit_operator expr
 bit_operator ::= '&' | '|' | '^' | '>>' | '<<'


### PR DESCRIPTION
Improved method modifiers support  like
`
static protected final function
`
Fixed chain of call syntax support
`
return (<ManagerInterface> this->_modelsManager)->setModelSchema(this, schema);
`
[zephir-project.tar.gz](https://github.com/zephir-lang/idea-plugin/files/1589734/zephir-project.tar.gz)

Note, please unpack file. Plugin was put into the archive